### PR TITLE
feat: add icon and ubuntu font for terminal launcher

### DIFF
--- a/public/terminal-icon.svg
+++ b/public/terminal-icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="8" ry="8" fill="#2e3436"/>
+  <polyline points="16,24 24,32 16,40" stroke="#fff" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  <line x1="28" y1="40" x2="48" y2="40" stroke="#fff" stroke-width="4" stroke-linecap="round"/>
+</svg>

--- a/src/app/desktop/desktop.component.css
+++ b/src/app/desktop/desktop.component.css
@@ -15,6 +15,14 @@
   margin: 1rem;
   cursor: pointer;
   user-select: none;
+  font-family: 'Ubuntu', sans-serif;
+}
+
+.icon img {
+  width: 48px;
+  height: 48px;
+  display: block;
+  margin: 0 auto 0.5rem;
 }
 
 app-terminal {

--- a/src/app/desktop/desktop.component.html
+++ b/src/app/desktop/desktop.component.html
@@ -1,6 +1,7 @@
 <div class="desktop" (contextmenu)="$event.preventDefault()">
   <div class="icon" (dblclick)="openTerminal()">
-    Terminal
+    <img src="terminal-icon.svg" alt="Terminal icon" />
+    <div class="label">Terminal</div>
   </div>
   <app-terminal *ngIf="terminalOpen" (closed)="closeTerminal()" />
 </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,1 +1,3 @@
+@import url('https://fonts.googleapis.com/css2?family=Ubuntu&display=swap');
+
 /* You can add global styles to this file, and also import other style files */


### PR DESCRIPTION
## Summary
- add SVG icon to terminal launcher button
- use Ubuntu font for terminal launcher text
- import Ubuntu font globally

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68908a5aee1c832f9015438b9cf1a655