### PR TITLE
feat: add Ubuntu-like desktop background and icon hover

### DIFF
--- a/public/ubuntu-wallpaper.svg
+++ b/public/ubuntu-wallpaper.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1920 1080">
+  <defs>
+    <radialGradient id="bg" cx="60%" cy="40%" r="80%">
+      <stop offset="0%" stop-color="#772953"/>
+      <stop offset="50%" stop-color="#5e2750"/>
+      <stop offset="100%" stop-color="#2c001e"/>
+    </radialGradient>
+    <radialGradient id="splash" cx="85%" cy="85%" r="60%">
+      <stop offset="0%" stop-color="#dd4814"/>
+      <stop offset="100%" stop-color="#772953" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="1920" height="1080" fill="url(#bg)"/>
+  <circle cx="1600" cy="900" r="800" fill="url(#splash)"/>
+</svg>

--- a/src/app/desktop/desktop.component.css
+++ b/src/app/desktop/desktop.component.css
@@ -4,7 +4,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background: #2e3436;
+  background: url('/ubuntu-wallpaper.svg') center/cover no-repeat fixed;
   color: #fff;
   font-family: sans-serif;
 }
@@ -16,6 +16,11 @@
   cursor: pointer;
   user-select: none;
   font-family: 'Ubuntu', sans-serif;
+}
+
+.icon:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+  border-radius: 4px;
 }
 
 .icon img {


### PR DESCRIPTION
## Summary
- add SVG wallpaper resembling Ubuntu colors
- highlight desktop icons on hover for better feedback

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*
- `apt-get update` *(fails: 403  Forbidden [IP: 172.30.2.35 8080])*

------
https://chatgpt.com/codex/tasks/task_e_68908be8eb2c832f902385cb293ca3dd