### PR TITLE
Add desktop sidebar with more icons

### DIFF
--- a/public/file-explorer-icon.svg
+++ b/public/file-explorer-icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <path d="M4 12h24l4 8h28v32H4z" fill="#ffc107" stroke="#e0a800" stroke-width="2" />
+</svg>
+

--- a/public/recycle-bin-icon.svg
+++ b/public/recycle-bin-icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect x="16" y="8" width="32" height="8" fill="#ccc" />
+  <rect x="12" y="16" width="40" height="40" fill="#eee" stroke="#ccc" stroke-width="2" />
+</svg>
+

--- a/src/app/desktop/desktop.component.css
+++ b/src/app/desktop/desktop.component.css
@@ -9,10 +9,23 @@
   font-family: sans-serif;
 }
 
+.sidebar {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: 80px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding-top: 1rem;
+  background-color: rgba(0, 0, 0, 0.2);
+}
+
 .icon {
   width: 64px;
   text-align: center;
-  margin: 1rem;
+  margin: 1rem 0;
   cursor: pointer;
   user-select: none;
   font-family: 'Ubuntu', sans-serif;

--- a/src/app/desktop/desktop.component.html
+++ b/src/app/desktop/desktop.component.html
@@ -1,7 +1,17 @@
 <div class="desktop" (contextmenu)="$event.preventDefault()">
-  <div class="icon" (dblclick)="openTerminal()">
-    <img src="terminal-icon.svg" alt="Terminal icon" />
-    <div class="label">Terminal</div>
+  <div class="sidebar">
+    <div class="icon">
+      <img src="recycle-bin-icon.svg" alt="Recycle Bin icon" />
+      <div class="label">Recycle Bin</div>
+    </div>
+    <div class="icon">
+      <img src="file-explorer-icon.svg" alt="File Explorer icon" />
+      <div class="label">File Explorer</div>
+    </div>
+    <div class="icon" (dblclick)="openTerminal()">
+      <img src="terminal-icon.svg" alt="Terminal icon" />
+      <div class="label">Terminal</div>
+    </div>
   </div>
   <app-terminal *ngIf="terminalOpen" (closed)="closeTerminal()" />
 </div>


### PR DESCRIPTION
## Summary
- Add vertical sidebar containing icons for Recycle Bin, File Explorer, and Terminal.
- Style sidebar and icons; Terminal icon still opens terminal while others are placeholders.
- Provide SVG assets for the new icons.

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_68908fb4646c832fb07724cf317f3652