### PR TITLE
feat: add basic file explorer

### DIFF
--- a/public/image-file-icon.svg
+++ b/public/image-file-icon.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <rect x="8" y="2" width="48" height="60" fill="#fff" stroke="#000"/>
+  <circle cx="26" cy="24" r="6" fill="#000"/>
+  <polygon points="16,52 32,32 48,52" fill="#999"/>
+</svg>

--- a/public/pdf-file-icon.svg
+++ b/public/pdf-file-icon.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <rect x="8" y="2" width="48" height="60" fill="#fff" stroke="#d00"/>
+  <rect x="8" y="34" width="48" height="28" fill="#d00"/>
+  <text x="20" y="54" font-size="20" fill="#fff" font-family="Arial">PDF</text>
+</svg>

--- a/public/text-file-icon.svg
+++ b/public/text-file-icon.svg
@@ -1,0 +1,6 @@
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <rect x="8" y="2" width="48" height="60" fill="#fff" stroke="#000"/>
+  <line x1="16" y1="20" x2="48" y2="20" stroke="#000" stroke-width="2"/>
+  <line x1="16" y1="28" x2="48" y2="28" stroke="#000" stroke-width="2"/>
+  <line x1="16" y1="36" x2="48" y2="36" stroke="#000" stroke-width="2"/>
+</svg>

--- a/src/app/apps/file-explorer/file-explorer.component.css
+++ b/src/app/apps/file-explorer/file-explorer.component.css
@@ -1,0 +1,55 @@
+.explorer-window {
+  width: 600px;
+  height: 400px;
+  background: #fff;
+  border: 1px solid #ccc;
+  display: flex;
+  flex-direction: column;
+  font-family: 'Ubuntu', sans-serif;
+}
+
+.explorer-header {
+  background: #f2f2f2;
+  padding: 4px 8px;
+  display: flex;
+  align-items: center;
+}
+
+.close {
+  background: #ff5c5c;
+  border: none;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  margin-right: 8px;
+  cursor: pointer;
+}
+
+.title {
+  font-weight: bold;
+}
+
+.explorer-body {
+  flex: 1;
+  padding: 8px;
+  display: flex;
+  flex-wrap: wrap;
+  align-content: flex-start;
+}
+
+.file-item {
+  width: 80px;
+  margin: 8px;
+  text-align: center;
+}
+
+.file-item img {
+  width: 48px;
+  height: 48px;
+  display: block;
+  margin: 0 auto 4px;
+}
+
+.name {
+  font-size: 12px;
+}

--- a/src/app/apps/file-explorer/file-explorer.component.html
+++ b/src/app/apps/file-explorer/file-explorer.component.html
@@ -1,0 +1,12 @@
+<div class="explorer-window">
+  <div class="explorer-header">
+    <button class="close" (click)="closed.emit()">x</button>
+    <span class="title">Files</span>
+  </div>
+  <div class="explorer-body">
+    <div class="file-item" *ngFor="let file of files">
+      <img [src]="getIcon(file)" [alt]="file.type + ' file icon'" />
+      <div class="name">{{file.name}}</div>
+    </div>
+  </div>
+</div>

--- a/src/app/apps/file-explorer/file-explorer.component.ts
+++ b/src/app/apps/file-explorer/file-explorer.component.ts
@@ -1,0 +1,35 @@
+import { Component, EventEmitter, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+interface FileItem {
+  name: string;
+  type: 'text' | 'image' | 'pdf';
+}
+
+@Component({
+  selector: 'app-file-explorer',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './file-explorer.component.html',
+  styleUrl: './file-explorer.component.css'
+})
+export class FileExplorerComponent {
+  @Output() closed = new EventEmitter<void>();
+
+  files: FileItem[] = [
+    { name: 'Document.txt', type: 'text' },
+    { name: 'Photo.png', type: 'image' },
+    { name: 'Report.pdf', type: 'pdf' }
+  ];
+
+  getIcon(file: FileItem): string {
+    switch (file.type) {
+      case 'image':
+        return 'image-file-icon.svg';
+      case 'pdf':
+        return 'pdf-file-icon.svg';
+      default:
+        return 'text-file-icon.svg';
+    }
+  }
+}

--- a/src/app/desktop/desktop.component.css
+++ b/src/app/desktop/desktop.component.css
@@ -48,3 +48,9 @@ app-terminal {
   top: 5rem;
   left: 5rem;
 }
+
+app-file-explorer {
+  position: absolute;
+  top: 5rem;
+  left: 15rem;
+}

--- a/src/app/desktop/desktop.component.html
+++ b/src/app/desktop/desktop.component.html
@@ -4,7 +4,7 @@
       <img src="recycle-bin-icon.svg" alt="Recycle Bin icon" />
       <div class="label">Recycle Bin</div>
     </div>
-    <div class="icon">
+    <div class="icon" (dblclick)="openFileExplorer()">
       <img src="file-explorer-icon.svg" alt="File Explorer icon" />
       <div class="label">File Explorer</div>
     </div>
@@ -14,4 +14,5 @@
     </div>
   </div>
   <app-terminal *ngIf="terminalOpen" (closed)="closeTerminal()" />
+  <app-file-explorer *ngIf="fileExplorerOpen" (closed)="closeFileExplorer()" />
 </div>

--- a/src/app/desktop/desktop.component.ts
+++ b/src/app/desktop/desktop.component.ts
@@ -1,16 +1,18 @@
 import { Component, HostListener } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { TerminalComponent } from '../apps/terminal/terminal.component';
+import { FileExplorerComponent } from '../apps/file-explorer/file-explorer.component';
 
 @Component({
   selector: 'app-desktop',
   standalone: true,
-  imports: [CommonModule, TerminalComponent],
+  imports: [CommonModule, TerminalComponent, FileExplorerComponent],
   templateUrl: './desktop.component.html',
   styleUrl: './desktop.component.css'
 })
 export class DesktopComponent {
   terminalOpen = false;
+  fileExplorerOpen = false;
 
   openTerminal() {
     this.terminalOpen = true;
@@ -18,6 +20,14 @@ export class DesktopComponent {
 
   closeTerminal() {
     this.terminalOpen = false;
+  }
+
+  openFileExplorer() {
+    this.fileExplorerOpen = true;
+  }
+
+  closeFileExplorer() {
+    this.fileExplorerOpen = false;
   }
 
   @HostListener('document:keydown.control.alt.t', ['$event'])


### PR DESCRIPTION
## Summary
- add file explorer app that displays sample text, image and PDF files with type-specific icons
- wire file explorer into desktop sidebar with double-click to open

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689095b3a66c832fbbc72240f18a6800