### PR TITLE
Enable selection highlighting for desktop and file explorer items

### DIFF
--- a/src/app/apps/file-explorer/file-explorer.component.css
+++ b/src/app/apps/file-explorer/file-explorer.component.css
@@ -52,6 +52,11 @@
   background: #f0f0f0;
 }
 
+.file-item.selected {
+  background: #cde5ff;
+  border: 1px solid #4a90e2;
+}
+
 .file-item img {
   width: 48px;
   height: 48px;

--- a/src/app/apps/file-explorer/file-explorer.component.html
+++ b/src/app/apps/file-explorer/file-explorer.component.html
@@ -3,8 +3,13 @@
     <button class="close" (click)="closed.emit()">x</button>
     <span class="title">Files</span>
   </div>
-  <div class="explorer-body">
-    <div class="file-item" *ngFor="let file of files">
+  <div class="explorer-body" (click)="selectFile(null)">
+    <div
+      class="file-item"
+      *ngFor="let file of files"
+      [class.selected]="selectedFile === file"
+      (click)="selectFile(file); $event.stopPropagation()"
+    >
       <img
         [src]="getIcon(file)"
         [alt]="file.type + ' file icon'"

--- a/src/app/apps/file-explorer/file-explorer.component.ts
+++ b/src/app/apps/file-explorer/file-explorer.component.ts
@@ -22,6 +22,8 @@ export class FileExplorerComponent {
     { name: 'Report.pdf', type: 'pdf' }
   ];
 
+  selectedFile: FileItem | null = null;
+
   getIcon(file: FileItem): string {
     switch (file.type) {
       case 'image':
@@ -31,5 +33,9 @@ export class FileExplorerComponent {
       default:
         return 'text-file-icon.svg';
     }
+  }
+
+  selectFile(file: FileItem | null) {
+    this.selectedFile = file;
   }
 }

--- a/src/app/desktop/desktop.component.css
+++ b/src/app/desktop/desktop.component.css
@@ -36,6 +36,12 @@
   border-radius: 4px;
 }
 
+.icon.selected {
+  background-color: rgba(255, 255, 255, 0.2);
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  border-radius: 4px;
+}
+
 .icon img {
   width: 48px;
   height: 48px;

--- a/src/app/desktop/desktop.component.html
+++ b/src/app/desktop/desktop.component.html
@@ -1,14 +1,28 @@
-<div class="desktop" (contextmenu)="$event.preventDefault()">
+<div class="desktop" (contextmenu)="$event.preventDefault()" (click)="clearSelection()">
   <div class="sidebar">
-    <div class="icon">
+    <div
+      class="icon"
+      [class.selected]="selectedIcon === 'recycle'"
+      (click)="selectIcon('recycle'); $event.stopPropagation()"
+    >
       <img src="recycle-bin-icon.svg" alt="Recycle Bin icon" />
       <div class="label">Recycle Bin</div>
     </div>
-    <div class="icon" (dblclick)="openFileExplorer()">
+    <div
+      class="icon"
+      [class.selected]="selectedIcon === 'explorer'"
+      (click)="selectIcon('explorer'); $event.stopPropagation()"
+      (dblclick)="openFileExplorer()"
+    >
       <img src="file-explorer-icon.svg" alt="File Explorer icon" />
       <div class="label">File Explorer</div>
     </div>
-    <div class="icon" (dblclick)="openTerminal()">
+    <div
+      class="icon"
+      [class.selected]="selectedIcon === 'terminal'"
+      (click)="selectIcon('terminal'); $event.stopPropagation()"
+      (dblclick)="openTerminal()"
+    >
       <img src="terminal-icon.svg" alt="Terminal icon" />
       <div class="label">Terminal</div>
     </div>

--- a/src/app/desktop/desktop.component.ts
+++ b/src/app/desktop/desktop.component.ts
@@ -13,6 +13,7 @@ import { FileExplorerComponent } from '../apps/file-explorer/file-explorer.compo
 export class DesktopComponent {
   terminalOpen = false;
   fileExplorerOpen = false;
+  selectedIcon: string | null = null;
 
   openTerminal() {
     this.terminalOpen = true;
@@ -28,6 +29,14 @@ export class DesktopComponent {
 
   closeFileExplorer() {
     this.fileExplorerOpen = false;
+  }
+
+  selectIcon(icon: string) {
+    this.selectedIcon = icon;
+  }
+
+  clearSelection() {
+    this.selectedIcon = null;
   }
 
   @HostListener('document:keydown.control.alt.t', ['$event'])


### PR DESCRIPTION
## Summary
- allow desktop icons to be selected and highlight the current selection
- enable selecting files in the file explorer with visual feedback

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: ChromeHeadless not found)*
- `apt-get update` *(fails: repository not signed)*
- `npm run build` *(fails: inlining fonts returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_6890b0940588832fba1b2c9f66761463