### PR TITLE
Add text editor app and desktop icon

### DIFF
--- a/public/text-editor-icon.svg
+++ b/public/text-editor-icon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect x="8" y="8" width="48" height="48" rx="4" ry="4" fill="#fff" stroke="#ccc" stroke-width="2"/>
+  <line x1="16" y1="20" x2="48" y2="20" stroke="#888" stroke-width="2"/>
+  <line x1="16" y1="28" x2="48" y2="28" stroke="#888" stroke-width="2"/>
+  <line x1="16" y1="36" x2="48" y2="36" stroke="#888" stroke-width="2"/>
+  <line x1="16" y1="44" x2="40" y2="44" stroke="#888" stroke-width="2"/>
+</svg>

--- a/src/app/apps/file-explorer/file-explorer.component.css
+++ b/src/app/apps/file-explorer/file-explorer.component.css
@@ -52,6 +52,11 @@
   background: #f0f0f0;
 }
 
+.file-item.selected {
+  background: #cde5ff;
+  border: 1px solid #4a90e2;
+}
+
 .file-item img {
   width: 48px;
   height: 48px;

--- a/src/app/apps/file-explorer/file-explorer.component.html
+++ b/src/app/apps/file-explorer/file-explorer.component.html
@@ -3,8 +3,13 @@
     <button class="close" (click)="closed.emit()">x</button>
     <span class="title">Files</span>
   </div>
-  <div class="explorer-body">
-    <div class="file-item" *ngFor="let file of files">
+  <div class="explorer-body" (click)="selectFile(null)">
+    <div
+      class="file-item"
+      *ngFor="let file of files"
+      [class.selected]="selectedFile === file"
+      (click)="selectFile(file); $event.stopPropagation()"
+    >
       <img
         [src]="getIcon(file)"
         [alt]="file.type + ' file icon'"

--- a/src/app/apps/file-explorer/file-explorer.component.ts
+++ b/src/app/apps/file-explorer/file-explorer.component.ts
@@ -22,6 +22,8 @@ export class FileExplorerComponent {
     { name: 'Report.pdf', type: 'pdf' }
   ];
 
+  selectedFile: FileItem | null = null;
+
   getIcon(file: FileItem): string {
     switch (file.type) {
       case 'image':
@@ -31,5 +33,9 @@ export class FileExplorerComponent {
       default:
         return 'text-file-icon.svg';
     }
+  }
+
+  selectFile(file: FileItem | null) {
+    this.selectedFile = file;
   }
 }

--- a/src/app/apps/text-editor/text-editor.component.css
+++ b/src/app/apps/text-editor/text-editor.component.css
@@ -1,0 +1,44 @@
+.editor-window {
+  width: 600px;
+  height: 400px;
+  background: #fff;
+  border: 1px solid #ccc;
+  display: flex;
+  flex-direction: column;
+  font-family: 'Ubuntu', sans-serif;
+}
+
+.editor-header {
+  background: #f2f2f2;
+  padding: 4px 8px;
+  display: flex;
+  align-items: center;
+}
+
+.close {
+  background: #ff5c5c;
+  border: none;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  margin-right: 8px;
+  cursor: pointer;
+}
+
+.title {
+  font-weight: bold;
+}
+
+.editor-body {
+  flex: 1;
+}
+
+.editor-body textarea {
+  width: 100%;
+  height: 100%;
+  resize: none;
+  border: none;
+  outline: none;
+  padding: 8px;
+  font-family: inherit;
+}

--- a/src/app/apps/text-editor/text-editor.component.html
+++ b/src/app/apps/text-editor/text-editor.component.html
@@ -1,0 +1,9 @@
+<div class="editor-window">
+  <div class="editor-header">
+    <button class="close" (click)="closed.emit()">x</button>
+    <span class="title">Text Editor</span>
+  </div>
+  <div class="editor-body">
+    <textarea [(ngModel)]="text"></textarea>
+  </div>
+</div>

--- a/src/app/apps/text-editor/text-editor.component.ts
+++ b/src/app/apps/text-editor/text-editor.component.ts
@@ -1,0 +1,15 @@
+import { Component, EventEmitter, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+
+@Component({
+  selector: 'app-text-editor',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './text-editor.component.html',
+  styleUrl: './text-editor.component.css'
+})
+export class TextEditorComponent {
+  @Output() closed = new EventEmitter<void>();
+  text = '';
+}

--- a/src/app/desktop/desktop.component.css
+++ b/src/app/desktop/desktop.component.css
@@ -36,6 +36,12 @@
   border-radius: 4px;
 }
 
+.icon.selected {
+  background-color: rgba(255, 255, 255, 0.2);
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  border-radius: 4px;
+}
+
 .icon img {
   width: 48px;
   height: 48px;
@@ -53,4 +59,10 @@ app-file-explorer {
   position: absolute;
   top: 5rem;
   left: 15rem;
+}
+
+app-text-editor {
+  position: absolute;
+  top: 5rem;
+  left: 25rem;
 }

--- a/src/app/desktop/desktop.component.html
+++ b/src/app/desktop/desktop.component.html
@@ -1,18 +1,42 @@
-<div class="desktop" (contextmenu)="$event.preventDefault()">
+<div class="desktop" (contextmenu)="$event.preventDefault()" (click)="clearSelection()">
   <div class="sidebar">
-    <div class="icon">
+    <div
+      class="icon"
+      [class.selected]="selectedIcon === 'recycle'"
+      (click)="selectIcon('recycle'); $event.stopPropagation()"
+    >
       <img src="recycle-bin-icon.svg" alt="Recycle Bin icon" />
       <div class="label">Recycle Bin</div>
     </div>
-    <div class="icon" (dblclick)="openFileExplorer()">
+    <div
+      class="icon"
+      [class.selected]="selectedIcon === 'explorer'"
+      (click)="selectIcon('explorer'); $event.stopPropagation()"
+      (dblclick)="openFileExplorer()"
+    >
       <img src="file-explorer-icon.svg" alt="File Explorer icon" />
       <div class="label">File Explorer</div>
     </div>
-    <div class="icon" (dblclick)="openTerminal()">
+    <div
+      class="icon"
+      [class.selected]="selectedIcon === 'terminal'"
+      (click)="selectIcon('terminal'); $event.stopPropagation()"
+      (dblclick)="openTerminal()"
+    >
       <img src="terminal-icon.svg" alt="Terminal icon" />
       <div class="label">Terminal</div>
+    </div>
+    <div
+      class="icon"
+      [class.selected]="selectedIcon === 'text-editor'"
+      (click)="selectIcon('text-editor'); $event.stopPropagation()"
+      (dblclick)="openTextEditor()"
+    >
+      <img src="text-editor-icon.svg" alt="Text Editor icon" />
+      <div class="label">Text Editor</div>
     </div>
   </div>
   <app-terminal *ngIf="terminalOpen" (closed)="closeTerminal()" />
   <app-file-explorer *ngIf="fileExplorerOpen" (closed)="closeFileExplorer()" />
+  <app-text-editor *ngIf="textEditorOpen" (closed)="closeTextEditor()" />
 </div>

--- a/src/app/desktop/desktop.component.ts
+++ b/src/app/desktop/desktop.component.ts
@@ -2,17 +2,20 @@ import { Component, HostListener } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { TerminalComponent } from '../apps/terminal/terminal.component';
 import { FileExplorerComponent } from '../apps/file-explorer/file-explorer.component';
+import { TextEditorComponent } from '../apps/text-editor/text-editor.component';
 
 @Component({
   selector: 'app-desktop',
   standalone: true,
-  imports: [CommonModule, TerminalComponent, FileExplorerComponent],
+  imports: [CommonModule, TerminalComponent, FileExplorerComponent, TextEditorComponent],
   templateUrl: './desktop.component.html',
   styleUrl: './desktop.component.css'
 })
 export class DesktopComponent {
   terminalOpen = false;
   fileExplorerOpen = false;
+  textEditorOpen = false;
+  selectedIcon: string | null = null;
 
   openTerminal() {
     this.terminalOpen = true;
@@ -30,10 +33,25 @@ export class DesktopComponent {
     this.fileExplorerOpen = false;
   }
 
+  openTextEditor() {
+    this.textEditorOpen = true;
+  }
+
+  closeTextEditor() {
+    this.textEditorOpen = false;
+  }
+
+  selectIcon(icon: string) {
+    this.selectedIcon = icon;
+  }
+
+  clearSelection() {
+    this.selectedIcon = null;
+  }
+
   @HostListener('document:keydown.control.alt.t', ['$event'])
   handleShortcut(event: KeyboardEvent) {
     event.preventDefault();
     this.openTerminal();
   }
 }
-


### PR DESCRIPTION
## Summary
- add basic text editor component with editable textarea and close button
- integrate text editor into desktop with launch icon, positioning, and icon selection behavior
- merge latest main changes into branch to incorporate desktop and file explorer selection features

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*
- `apt-get update` *(fails: repository 403 Forbidden; unable to install Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_6890b0cb9228832facdc7309a7a80ceb