### PR TITLE
feat: enable draggable windows

### DIFF
--- a/src/app/desktop/desktop.component.html
+++ b/src/app/desktop/desktop.component.html
@@ -36,7 +36,22 @@
       <div class="label">Text Editor</div>
     </div>
   </div>
-  <app-terminal *ngIf="terminalOpen" (closed)="closeTerminal()" />
-  <app-file-explorer *ngIf="fileExplorerOpen" (closed)="closeFileExplorer()" />
-  <app-text-editor *ngIf="textEditorOpen" (closed)="closeTextEditor()" />
+  <app-terminal
+    *ngIf="terminalOpen"
+    (closed)="closeTerminal()"
+    appDraggable
+    appDraggableHandle=".terminal-header"
+  />
+  <app-file-explorer
+    *ngIf="fileExplorerOpen"
+    (closed)="closeFileExplorer()"
+    appDraggable
+    appDraggableHandle=".explorer-header"
+  />
+  <app-text-editor
+    *ngIf="textEditorOpen"
+    (closed)="closeTextEditor()"
+    appDraggable
+    appDraggableHandle=".editor-header"
+  />
 </div>

--- a/src/app/desktop/desktop.component.ts
+++ b/src/app/desktop/desktop.component.ts
@@ -3,11 +3,12 @@ import { CommonModule } from '@angular/common';
 import { TerminalComponent } from '../apps/terminal/terminal.component';
 import { FileExplorerComponent } from '../apps/file-explorer/file-explorer.component';
 import { TextEditorComponent } from '../apps/text-editor/text-editor.component';
+import { DraggableDirective } from '../draggable.directive';
 
 @Component({
   selector: 'app-desktop',
   standalone: true,
-  imports: [CommonModule, TerminalComponent, FileExplorerComponent, TextEditorComponent],
+  imports: [CommonModule, TerminalComponent, FileExplorerComponent, TextEditorComponent, DraggableDirective],
   templateUrl: './desktop.component.html',
   styleUrl: './desktop.component.css'
 })

--- a/src/app/draggable.directive.ts
+++ b/src/app/draggable.directive.ts
@@ -1,0 +1,63 @@
+import { AfterViewInit, Directive, ElementRef, Input, OnDestroy, Renderer2 } from '@angular/core';
+
+@Directive({
+  selector: '[appDraggable]',
+  standalone: true,
+})
+export class DraggableDirective implements AfterViewInit, OnDestroy {
+  @Input('appDraggableHandle') handleSelector = '';
+
+  private handleEl?: HTMLElement;
+  private moveListener: (() => void) | null = null;
+  private upListener: (() => void) | null = null;
+  private offsetX = 0;
+  private offsetY = 0;
+
+  constructor(private el: ElementRef<HTMLElement>, private renderer: Renderer2) {}
+
+  ngAfterViewInit() {
+    const nativeEl = this.el.nativeElement;
+    this.handleEl = this.handleSelector
+      ? (nativeEl.querySelector(this.handleSelector) as HTMLElement | null) || undefined
+      : nativeEl;
+    if (this.handleEl) {
+      this.handleEl.addEventListener('mousedown', this.onMouseDown);
+      this.handleEl.style.cursor = 'move';
+    }
+  }
+
+  ngOnDestroy() {
+    this.handleEl?.removeEventListener('mousedown', this.onMouseDown);
+    this.removeListeners();
+  }
+
+  private onMouseDown = (event: MouseEvent) => {
+    event.preventDefault();
+    const nativeEl = this.el.nativeElement;
+    this.offsetX = event.clientX - nativeEl.offsetLeft;
+    this.offsetY = event.clientY - nativeEl.offsetTop;
+    this.moveListener = this.renderer.listen('document', 'mousemove', this.onMouseMove);
+    this.upListener = this.renderer.listen('document', 'mouseup', this.onMouseUp);
+  };
+
+  private onMouseMove = (event: MouseEvent) => {
+    this.renderer.setStyle(this.el.nativeElement, 'left', `${event.clientX - this.offsetX}px`);
+    this.renderer.setStyle(this.el.nativeElement, 'top', `${event.clientY - this.offsetY}px`);
+  };
+
+  private onMouseUp = () => {
+    this.removeListeners();
+  };
+
+  private removeListeners() {
+    if (this.moveListener) {
+      this.moveListener();
+      this.moveListener = null;
+    }
+    if (this.upListener) {
+      this.upListener();
+      this.upListener = null;
+    }
+  }
+}
+


### PR DESCRIPTION
## Summary
- allow dragging app windows by their headers using a new `DraggableDirective`
- apply dragging behavior to terminal, file explorer, and text editor windows

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_689198ed8980832fb2e60496c18c0a19