### PR TITLE
feat: manage desktop apps dynamically

### DIFF
--- a/src/app/desktop.service.ts
+++ b/src/app/desktop.service.ts
@@ -1,4 +1,16 @@
-import { Injectable } from '@angular/core';
+import {
+  Injectable,
+  ComponentRef,
+  Type,
+  ViewContainerRef,
+  ElementRef,
+  Renderer2,
+  RendererFactory2,
+} from '@angular/core';
+import { TerminalComponent } from './apps/terminal/terminal.component';
+import { FileExplorerComponent } from './apps/file-explorer/file-explorer.component';
+import { TextEditorComponent } from './apps/text-editor/text-editor.component';
+import { DraggableDirective } from './draggable.directive';
 
 export interface DesktopApp {
   id: string;
@@ -15,21 +27,63 @@ export class DesktopService {
     { id: 'text-editor', label: 'Text Editor', icon: 'text-editor-icon.svg' },
   ];
 
-  private openApps = new Set<string>();
+  private container?: ViewContainerRef;
+  private componentMap: Record<string, Type<any>> = {
+    explorer: FileExplorerComponent,
+    terminal: TerminalComponent,
+    'text-editor': TextEditorComponent,
+  };
+  private handleMap: Record<string, string> = {
+    explorer: '.explorer-header',
+    terminal: '.terminal-header',
+    'text-editor': '.editor-header',
+  };
+
+  private openAppRefs = new Map<string, ComponentRef<any>>();
+  private renderer: Renderer2;
+
+  constructor(rendererFactory: RendererFactory2) {
+    this.renderer = rendererFactory.createRenderer(null, null);
+  }
 
   getApps() {
     return this.icons;
   }
 
+  registerContainer(container: ViewContainerRef) {
+    this.container = container;
+  }
+
   openApp(id: string) {
-    this.openApps.add(id);
+    if (!this.container || this.openAppRefs.has(id)) {
+      return;
+    }
+    const component = this.componentMap[id];
+    if (!component) {
+      return;
+    }
+    const ref = this.container.createComponent(component);
+    const element = ref.location.nativeElement as HTMLElement;
+    const draggable = new DraggableDirective(
+      new ElementRef(element),
+      this.renderer
+    );
+    draggable.handleSelector = this.handleMap[id];
+    draggable.ngAfterViewInit();
+    (ref.instance as any).closed?.subscribe(() => this.closeApp(id));
+    ref.onDestroy(() => draggable.ngOnDestroy());
+    this.openAppRefs.set(id, ref);
   }
 
   closeApp(id: string) {
-    this.openApps.delete(id);
+    const ref = this.openAppRefs.get(id);
+    if (ref) {
+      ref.destroy();
+      this.openAppRefs.delete(id);
+    }
   }
 
   isAppOpen(id: string) {
-    return this.openApps.has(id);
+    return this.openAppRefs.has(id);
   }
 }

--- a/src/app/desktop/desktop.component.html
+++ b/src/app/desktop/desktop.component.html
@@ -11,22 +11,5 @@
       <div class="label">{{ app.label }}</div>
     </div>
   </div>
-  <app-terminal
-    *ngIf="isAppOpen('terminal')"
-    (closed)="closeApp('terminal')"
-    appDraggable
-    appDraggableHandle=".terminal-header"
-  />
-  <app-file-explorer
-    *ngIf="isAppOpen('explorer')"
-    (closed)="closeApp('explorer')"
-    appDraggable
-    appDraggableHandle=".explorer-header"
-  />
-  <app-text-editor
-    *ngIf="isAppOpen('text-editor')"
-    (closed)="closeApp('text-editor')"
-    appDraggable
-    appDraggableHandle=".editor-header"
-  />
+  <ng-container #appContainer></ng-container>
 </div>

--- a/src/app/desktop/desktop.component.ts
+++ b/src/app/desktop/desktop.component.ts
@@ -1,36 +1,31 @@
-import { Component, HostListener } from '@angular/core';
+import { Component, HostListener, ViewChild, ViewContainerRef, AfterViewInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { TerminalComponent } from '../apps/terminal/terminal.component';
-import { FileExplorerComponent } from '../apps/file-explorer/file-explorer.component';
-import { TextEditorComponent } from '../apps/text-editor/text-editor.component';
-import { DraggableDirective } from '../draggable.directive';
 import { DesktopService, DesktopApp } from '../desktop.service';
 
 @Component({
   selector: 'app-desktop',
   standalone: true,
-  imports: [CommonModule, TerminalComponent, FileExplorerComponent, TextEditorComponent, DraggableDirective],
+  imports: [CommonModule],
   templateUrl: './desktop.component.html',
   styleUrl: './desktop.component.css'
 })
-export class DesktopComponent {
+export class DesktopComponent implements AfterViewInit {
   apps: DesktopApp[] = [];
   selectedIcon: string | null = null;
+
+  @ViewChild('appContainer', { read: ViewContainerRef })
+  appContainer!: ViewContainerRef;
 
   constructor(private desktopService: DesktopService) {
     this.apps = this.desktopService.getApps();
   }
 
+  ngAfterViewInit() {
+    this.desktopService.registerContainer(this.appContainer);
+  }
+
   openApp(id: string) {
     this.desktopService.openApp(id);
-  }
-
-  closeApp(id: string) {
-    this.desktopService.closeApp(id);
-  }
-
-  isAppOpen(id: string) {
-    return this.desktopService.isAppOpen(id);
   }
 
   selectIcon(icon: string) {


### PR DESCRIPTION
## Summary
- refactor desktop service to spawn and remove app components on demand
- register desktop container so service appends app windows dynamically
- simplify desktop component and template to rely on service-driven app instantiation

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*
- `apt-get update` *(fails: repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6891a33fa664832f805628b17cc662d3